### PR TITLE
include libraries

### DIFF
--- a/templates/assignment_template.rmd
+++ b/templates/assignment_template.rmd
@@ -42,7 +42,7 @@ knitr::opts_chunk$set(echo = TRUE)
 
 Below are examples of how to load packages that are used in the assignment
 
-```{r, eval=FALSE}
+```{r, include=FALSE}
 library(ggplot2)
 ```
 


### PR DESCRIPTION
libraries were not loaded in the rmd assignment template before, creating problems when knitting, I suggest this update to the template. 